### PR TITLE
Make Objects check if they should be solid before switching materials

### DIFF
--- a/Assets/HyperScripts/HyperObject.cs
+++ b/Assets/HyperScripts/HyperObject.cs
@@ -273,7 +273,7 @@ public class HyperObject : MonoBehaviour {
 
         _cachedRenderer.material.color = targetColor;
 
-        if(targetA == 1f && !staticRenderMode)
+        if(targetA == 1f && !staticRenderMode && isVisibleSolid(hypPlayer.w))
         {
             _cachedRenderer.material.SetFloat("_Mode", 0);
             _cachedRenderer.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);


### PR DESCRIPTION
objects have a second check before changing rendering mode to prevent
the worong rendering mode from being applied to the object
